### PR TITLE
remove github dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,11 +19,9 @@ Suggests:
     tidyr,
     lubridate,
     ggplot2,
-    janitor,
-    phsmethods
+    janitor
 Imports: 
     captioner,
     flextable (>= 0.5.7),
     officer,
     renv
-Remotes: Health-SocialCare-Scotland/phsmethods

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install this package by running the following code in R:
 devtools::install_github("Health-SocialCare-Scotland/phstemplates")
 ```
 
-If you are working inside the NSS network then this may not work in which case follow these steps:
+If you are working inside the PHS network then this may not work in which case follow these steps:
 1. Click **Clone or download**
 2. Click **Download ZIP**
 3. Save the zip file locally

--- a/inst/rmarkdown/templates/hps-stats-report/skeleton/compile.R
+++ b/inst/rmarkdown/templates/hps-stats-report/skeleton/compile.R
@@ -1,0 +1,57 @@
+# Load required libraries
+library(officer)
+library(magrittr)
+
+
+# Check Filepaths Exist
+rmd_exists <- file.exists(params$rmd_filename)
+cover_exists <- file.exists(params$cover_filename)
+
+if (!rmd_exists) {
+  message("Error: Cannot find the input Rmd file. Have you input the wrong filename?")
+}
+
+if (!cover_exists) {
+  message("Error: Cannot find the input Cover Page file. Have you input the wrong filename?")
+}
+
+if (!(rmd_exists && cover_exists)) {
+  message("If you are not using full filepaths to your input files:")
+  message("Has the working directory been set properly?\n")
+  message("Here is your working directory\n", getwd(), "\n")
+  message("and here are the files in it")
+  print(list.files())
+
+  message("If the input files you expect to see are not listed, the working directory will be wrong")
+} else {
+  message("Found all required input files. Compiling report...")
+
+  # Create Report and Add Table of Contents
+  rmarkdown::render(params$rmd_filename, output_file = "temp_report.docx",
+                    envir = new.env())
+
+  read_docx("temp_report.docx") %>%
+    cursor_reach(keyword = "Introduction") %>%
+    body_add_break(pos = "before") %>%
+    body_add_toc() %>%
+    body_add_par("Contents", pos = "before", style = "Contents Header") %>%
+    cursor_reach(keyword = "Introduction") %>%
+    body_add_break(pos = "before") %>%
+    print("temp_report2.docx")
+
+  # Cover Page
+  cover_page <- read_docx("Cover_Page.docx") %>%
+    body_replace_all_text("Insert publication title here", params$title) %>%
+    body_replace_all_text("Subtitle", params$subtitle) %>%
+    body_replace_all_text("DD Month YYYY", params$date)
+
+  # Combine Cover and Report
+  cover_page %>%
+    body_add_break() %>%
+    cursor_end() %>%
+    body_add_docx("temp_report2.docx") %>%
+    print(params$filename_out)
+
+  # Remove Temporary Files
+  unlink(c("temp_report.docx", "temp_report2.docx"))
+}

--- a/inst/rmarkdown/templates/hps-stats-report/skeleton/create_report.R
+++ b/inst/rmarkdown/templates/hps-stats-report/skeleton/create_report.R
@@ -1,63 +1,45 @@
 # Compile report with table of contents and front cover included
 
-# PLEASE READ:
-# When the report has been compiled with the table of contents and cover page
-# included, there will be a warning when you open the report saying that the
-# document contains fields that may refer to other files: click Yes
-# If you want to get rid of this warning, re-save the file after opening it
 
-# Load required libraries
-library(officer)
-library(magrittr)
 
-# Parameters - This should be the only section that needs edited
-# Change as required for your publication
-# Note: filenames need to be filepaths if they are not stored in your R working
-# directory
+# Parameters --------------------------------------------------------------
+# Please change as required for your publication
+# Note: filenames need to be filepaths if they are not stored in your current R
+# working directory
+
 params <- list(
+  # Report filename - Please check carefully
   rmd_filename    = "Report.Rmd",
+  # Cover page filename - Please check carefully
   cover_filename  = "Cover_Page.docx",
+  # Title for cover page
   title           = "My Title",
+  # Subtitle for cover page
   subtitle        = "My Subtitle",
+  # Date of Publication
   date            = "DD Month YYYY",
+  # Output filename for compiled report
   filename_out    = "Report_and_Cover.docx"
 )
 
 
 
-# Create Report and Add Table of Contents ---------------------------------
+# Compile Report ----------------------------------------------------------
 
-rmarkdown::render(params$rmd_filename, output_file = "temp_report.docx",
-                  envir = new.env())
-
-read_docx("temp_report.docx") %>%
-  cursor_reach(keyword = "Introduction") %>%
-  body_add_break(pos = "before") %>%
-  body_add_toc() %>%
-  body_add_par("Contents", pos = "before", style = "Contents Header") %>%
-  print("temp_report2.docx")
+# Note: if source() below cannot find the 'compile.R' file, check that your
+# current working directory contains the 'compile.R' file
+# Check your current working directory with getwd()
+# If needed, set your working directory using setwd() to the directory that
+# contains 'compile.R'
+source("compile.R")
 
 
-
-# Cover Page --------------------------------------------------------------
-
-cover_page <- read_docx("Cover_Page.docx") %>%
-  body_replace_all_text("Insert publication title here", params$title) %>%
-  body_replace_all_text("Subtitle", params$subtitle) %>%
-  body_replace_all_text("DD Month YYYY", params$date)
-
-
-
-# Combine Cover and Report ------------------------------------------------
-
-cover_page %>%
-  body_add_break() %>%
-  cursor_end() %>%
-  body_add_docx("temp_report2.docx") %>%
-  print(params$filename_out)
-
-
-
-# Remove Temporary Files --------------------------------------------------
-
-unlink(c("temp_report.docx", "temp_report2.docx"))
+# PLEASE READ
+# When the report has been compiled with the table of contents and cover page
+# included, keep a note of the following:
+# In Word 2007, there may be a warning popup when you open the report saying that
+# the document contains fields that may refer to other files: click Yes
+# If you want to get rid of this warning, re-save the file after opening it
+# In Word 2016, there may be no warning popup but the table of contents may not
+# immediately appear - to make it appear go to the 'References' tab and click
+# 'Update Table'


### PR DESCRIPTION
Updates to the HPS non-1.2 RMarkdown template.
Removed dependency to phsmethods as Github dependencies were causing me install problems when on the network (even though its only a weak dependency listed under 'Suggests') and think it's safer to keep only CRAN dependencies
Other minor changes.